### PR TITLE
respect linux case sensitive filesystem

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grammars": [{
       "language": "textFSM",
       "scopeName": "text.textFSM",
-      "path": "./syntaxes/textFSM.tmlanguage.json"
+      "path": "./syntaxes/textFSM.tmLanguage.json"
     }]
   }
 }


### PR DESCRIPTION
The linux filesystem is case sensitive, so the grammar file wasn't found. With this fix, now works in Linux